### PR TITLE
Enable logging and randomize test value.

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+log_cli = 1
+log_format = %(asctime)s %(levelname)s %(message)s
+log_date_format = %Y-%m-%d %H:%M:%S
+log_cli_level=INFO

--- a/tests/game01/24_create_a_configmap/answer.template.yaml
+++ b/tests/game01/24_create_a_configmap/answer.template.yaml
@@ -9,5 +9,5 @@ metadata:
   name: config
   namespace: {{namespace}}
 data:
-  foo: lala
-  foo2: lolo
+  foo: {{value1}}
+  foo2: {{value2}}

--- a/tests/game01/24_create_a_configmap/instruction.md
+++ b/tests/game01/24_create_a_configmap/instruction.md
@@ -1,1 +1,1 @@
-In the '{{namespace}}' namespace, create a configmap named config with values foo=lala, and foo2=lolo.
+In the '{{namespace}}' namespace, create a configmap named config with values foo={{value1}}, and foo2={{value2}}.

--- a/tests/game01/24_create_a_configmap/session.json
+++ b/tests/game01/24_create_a_configmap/session.json
@@ -1,3 +1,5 @@
 {
-    "namespace": "{{random_name()}}{{random_number(1,10)}}{{student_id()}}"
+    "namespace": "{{random_name()}}{{random_number(1,10)}}{{student_id()}}",
+    "value1":"{{random_name()}}",
+    "value2":"{{random_name()}}"
 }

--- a/tests/game01/24_create_a_configmap/test_05_check.py
+++ b/tests/game01/24_create_a_configmap/test_05_check.py
@@ -29,9 +29,13 @@ class TestCheckConfigMap:
         assert configmap.kind == "ConfigMap", "Incorrect kind."
         assert configmap.metadata.name == configmap_name, "Incorrect metadata.name."
         assert "foo" in configmap.data, "Missing key 'foo' in data."
-        assert configmap.data["foo"] == "lala", "Incorrect value for 'foo'."
+        assert (
+            configmap.data["foo"] == json_input["value1"]
+        ), "Incorrect value for 'foo'."
         assert "foo2" in configmap.data, "Missing key 'foo2' in data."
-        assert configmap.data["foo2"] == "lolo", "Incorrect value for 'foo2'."
+        assert (
+            configmap.data["foo2"] == json_input["value2"]
+        ), "Incorrect value for 'foo2'."
         logging.info("ConfigMap '%s' has the correct content.", configmap_name)
 
     def test_002_check_configmap_kubectl(self, json_input):
@@ -52,7 +56,11 @@ class TestCheckConfigMap:
         assert configmap["kind"] == "ConfigMap", "Incorrect kind."
         assert configmap["metadata"]["name"] == "config", "Incorrect metadata.name."
         assert "foo" in configmap["data"], "Missing key 'foo' in data."
-        assert configmap["data"]["foo"] == "lala", "Incorrect value for 'foo'."
+        assert (
+            configmap["data"]["foo"] == json_input["value1"]
+        ), "Incorrect value for 'foo'."
         assert "foo2" in configmap["data"], "Missing key 'foo2' in data."
-        assert configmap["data"]["foo2"] == "lolo", "Incorrect value for 'foo2'."
+        assert (
+            configmap["data"]["foo2"] == json_input["value2"]
+        ), "Incorrect value for 'foo2'."
         logging.info("ConfigMap 'config' has the correct content.")


### PR DESCRIPTION
This pull request includes changes to improve logging configuration and update the ConfigMap creation process in the tests. The most important changes include adding logging configuration to `pytest.ini`, parameterizing the ConfigMap values, and updating test assertions to reflect these changes.

Logging configuration:

* [`pytest.ini`](diffhunk://#diff-fb6a686182f16eb54af3c628f38593f347f68aba31de903983023c560288d7a1R1-R5): Added configuration for logging, including enabling CLI logging, setting log format, date format, and log level.

Parameterization of ConfigMap values:

* [`tests/game01/24_create_a_configmap/answer.template.yaml`](diffhunk://#diff-10063a8579e09f456878df255fb5fc883dd5ba564ec6c8ffee0987dac22878f8L12-R13): Updated `foo` and `foo2` values to be parameterized using `{{value1}}` and `{{value2}}` respectively.
* [`tests/game01/24_create_a_configmap/instruction.md`](diffhunk://#diff-0e5aea1674c358a0e932e012accec354df3b4e8aafada9e04a275e9fd31ce228L1-R1): Modified instructions to reflect the parameterized values for `foo` and `foo2`.
* [`tests/game01/24_create_a_configmap/session.json`](diffhunk://#diff-e5050433a1154eff706ead178060f1f45c0c3dfb45c6dc2e2c6b0ad29c091060L2-R4): Added `value1` and `value2` parameters to the session JSON.

Test updates:

* [`tests/game01/24_create_a_configmap/test_05_check.py`](diffhunk://#diff-0260c103df7e9a464cccccc5e77ae5ff7080bbe1c9e643443c66a5ac8799c1f8L32-R38): Updated assertions in `test_001_check_configmap_client` and `test_002_check_configmap_kubectl` to check for parameterized values `value1` and `value2` instead of hardcoded values. [[1]](diffhunk://#diff-0260c103df7e9a464cccccc5e77ae5ff7080bbe1c9e643443c66a5ac8799c1f8L32-R38) [[2]](diffhunk://#diff-0260c103df7e9a464cccccc5e77ae5ff7080bbe1c9e643443c66a5ac8799c1f8L55-R65)